### PR TITLE
Simplify top bar with standalone logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,8 +89,6 @@
       box-shadow:var(--shadow);
     }
     .title{ display:flex; align-items:center; gap:10px; }
-    h1{ font-size:1.25rem; margin:0; font-weight:650; letter-spacing:.2px; }
-    .subtitle{ margin:0; font-size:.85rem; color:var(--muted); }
 
     .toolbar-actions{ display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
     .search{ position:relative; min-width:220px; }
@@ -260,10 +258,7 @@
   <div class="container">
     <div class="toolbar">
       <div class="title">
-        <img src="jobbee_small.png" alt="Jobbee logo" width="22" height="22">
-        <div>
-          <h1>Jobbee</h1>
-        </div>
+        <img src="jobbee_small.png" alt="Jobbee logo" width="40" height="40">
       </div>
       <div class="toolbar-actions">
         <div class="search">


### PR DESCRIPTION
## Summary
- Remove text label from top toolbar and display only the Jobbee logo
- Increase logo size for better visibility

## Testing
- `npm test` *(fails: ENOENT, package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c555bc87048325adcc9b42e6a4ee74