### PR TITLE
Load default job applications when local storage empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -419,6 +419,20 @@
         items = raw ? JSON.parse(raw) : [];
         if(!Array.isArray(items)) items = [];
       }catch(e){ items = []; }
+      if(items.length === 0){
+        (async () => {
+          try{
+            const res = await fetch('job-applications.json');
+            const obj = await res.json();
+            const arr = Array.isArray(obj) ? obj : (Array.isArray(obj.data) ? obj.data : []);
+            if(Array.isArray(arr)){
+              items = arr;
+              save();
+              render();
+            }
+          }catch(err){ /* ignore if file missing or invalid */ }
+        })();
+      }
       try{
         const cs = localStorage.getItem(COL_STATE_KEY);
         collapsed = cs ? JSON.parse(cs) : {};


### PR DESCRIPTION
## Summary
- Fetch `job-applications.json` as a fallback when local storage has no entries
- Save and re-render after loading default data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c557bf707483259a8c99aa7bc1fe27