### PR TITLE
Adjust header layout and add donation note

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,15 +83,17 @@
 
     /* Toolbar */
     .toolbar{
-      display:flex; align-items:center; justify-content:space-between; gap:12px;
+      display:flex; flex-direction:column; gap:12px;
       margin-bottom:16px; padding:14px 16px;
-      background:#f8f4eb; border:1px solid var(--border); border-radius:var(--radius);
+      background:#fff; border:1px solid var(--border); border-radius:var(--radius);
       box-shadow:var(--shadow);
     }
+    .toolbar-main{ display:flex; align-items:center; justify-content:space-between; gap:12px; }
     .title{ display:flex; align-items:center; gap:10px; }
 
     .toolbar-actions{ display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
-    .search{ position:relative; width: calc(var(--btn-w) * 3 + 20px); max-width:100%; }
+    .filters{ display:flex; flex-direction:column; width: calc(var(--btn-w) * 3 + 20px); max-width:100%; gap:8px; }
+    .search{ position:relative; width:100%; }
     .search input[type="search"]{
       width:100%; padding:10px 12px 10px 34px; border:1px solid var(--border);
       background:#fff; color:var(--text); border-radius:var(--radius-sm); outline:none;
@@ -108,7 +110,7 @@
     textarea{ resize:vertical }
 
     #sort{
-      width: calc(var(--btn-w) * 3 + 20px);
+      width:100%;
       max-width:100%;
     }
 
@@ -253,7 +255,7 @@
 
     /* Small screens */
     @media (max-width: 760px){
-      .toolbar{ flex-direction:column; align-items:stretch }
+      .toolbar-main{ flex-direction:column; align-items:stretch }
       .toolbar-actions{ justify-content:space-between }
       .grid{ grid-template-columns: 1fr }
     }
@@ -262,43 +264,48 @@
 <body>
   <div class="container">
     <div class="toolbar">
-      <div class="title">
-        <img src="jobbee_small.png" alt="Jobbee logo" width="120" height="120">
-      </div>
-      <div class="toolbar-actions">
-        <div class="search">
-          <input id="search" type="search" placeholder="Keyword Filter" aria-label="Search applications">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-            <circle cx="11" cy="11" r="7" stroke="#94a3b8" stroke-width="1.5"/>
-            <path d="M20 20l-3.5-3.5" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/>
-          </svg>
+      <div class="toolbar-main">
+        <div class="title">
+          <img src="jobbee_small.png" alt="Jobbee logo" width="120" height="120">
         </div>
-        <select id="sort" aria-label="Sort">
-          <option value="date_desc">Newest first</option>
-          <option value="date_asc">Oldest first</option>
-          <option value="company_asc">Company A–Z</option>
-          <option value="company_desc">Company Z–A</option>
-        </select>
-        <button id="addBtn" class="btn btn-cta btn-add" title="Add a new application" aria-label="Add a new application">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-            <path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
-          </svg>
-          Add
-        </button>
-        <button id="exportJsonBtn" class="btn btn-cta btn-export" title="Download a backup" aria-label="Export applications">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-            <path d="M12 3v12m0 0l-4-4m4 4l4-4M4 21h16" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-          Export
-        </button>
-        <label for="importJsonInput" class="btn btn-cta btn-import" title="Import from a backup" aria-label="Import applications" style="cursor:pointer">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-            <path d="M12 21V9m0 0l4 4m-4-4L8 13M4 3h16" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-          Import
-          <input id="importJsonInput" type="file" accept="application/json" hidden>
-        </label>
+        <div class="toolbar-actions">
+          <div class="filters">
+            <div class="search">
+              <input id="search" type="search" placeholder="Keyword Filter" aria-label="Search applications">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <circle cx="11" cy="11" r="7" stroke="#94a3b8" stroke-width="1.5"/>
+                <path d="M20 20l-3.5-3.5" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/>
+              </svg>
+            </div>
+            <select id="sort" aria-label="Sort">
+              <option value="date_desc">Newest first</option>
+              <option value="date_asc">Oldest first</option>
+              <option value="company_asc">Company A–Z</option>
+              <option value="company_desc">Company Z–A</option>
+            </select>
+          </div>
+          <button id="addBtn" class="btn btn-cta btn-add" title="Add a new application" aria-label="Add a new application">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+            </svg>
+            Add
+          </button>
+          <button id="exportJsonBtn" class="btn btn-cta btn-export" title="Download a backup" aria-label="Export applications">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M12 3v12m0 0l-4-4m4 4l4-4M4 21h16" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            Export
+          </button>
+          <label for="importJsonInput" class="btn btn-cta btn-import" title="Import from a backup" aria-label="Import applications" style="cursor:pointer">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M12 21V9m0 0l4 4m-4-4L8 13M4 3h16" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            Import
+            <input id="importJsonInput" type="file" accept="application/json" hidden>
+          </label>
+        </div>
       </div>
+      <p class="footnote">Free to use. If this helps you land a job, maybe <a href="https://buymeacoffee.com/stevedrasco" class="link" target="_blank">throw its creator a bone</a>.</p>
     </div>
 
     <div id="board" class="board" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- Make toolbar background white and restructure with `.toolbar-main` wrapper
- Stack sorting dropdown beneath keyword filter
- Add small donation footnote with link to Buy Me a Coffee

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c55d68ef088325badff311b242d411