### PR TITLE
Add tooltip with local storage deletion instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
 
     <div id="board" class="board" aria-live="polite"></div>
     <p id="emptyState" class="empty">No applications yet. Click <b>Add</b> to create your first entry. <br> Or <a href="job-applications.json" download>download our silly example file</a> and import it to see how things look.</p>
-    <p class="footnote">Your data is saved privately on your computer (local storage). Use Export to back up and Import to restore.</p>
+    <p class="footnote" title="To delete your data:&#10;1) Open your browser's developer tools (press F12).&#10;2) Go to the Application or Storage tab, then Local Storage for this site.&#10;3) Delete jobApplications.v1, jobApplications.columnsCollapsed.v1, and jobApplications.sort.v1, or clear all site data.&#10;You can also run localStorage.removeItem('jobApplications.v1') and similar commands in the console.&#10;This only removes the copy on your computer; nothing is stored on our server.">Your data is saved privately on your computer (local storage). Use Export to back up and Import to restore.</p>
   </div>
 
   <!-- Add / Edit Modal -->


### PR DESCRIPTION
## Summary
- add hover tooltip to data privacy note with step-by-step instructions for deleting local storage entries

## Testing
- `npx prettier --check index.html` *(reports code style differences)*

------
https://chatgpt.com/codex/tasks/task_e_68c5615883408325ae95cc6786407728