### PR TITLE
Add confirmation step before clearing local data

### DIFF
--- a/index.html
+++ b/index.html
@@ -467,7 +467,7 @@
     function saveColState(){ localStorage.setItem(COL_STATE_KEY, JSON.stringify(collapsed)); }
 
     function clearData(){
-      const ok = confirm("Clear all locally stored data?");
+      const ok = confirm("Are you sure you want to clear your local data? This will permanently delete your saved applications and the default sample data will be shown again.");
       if(!ok) return;
       localStorage.removeItem(LS_KEY);
       localStorage.removeItem(COL_STATE_KEY);


### PR DESCRIPTION
## Summary
- Ask users to confirm before clearing locally stored job data
- Warn that clearing data permanently deletes applications and restores sample listings

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c56dc3f7008325bfe2ed119fb12cfe